### PR TITLE
Style changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gds-present

--- a/static/styles.css
+++ b/static/styles.css
@@ -56,11 +56,6 @@ body {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
 
-  border-radius: 10px;
-  -o-border-radius: 10px;
-  -moz-border-radius: 10px;
-  -webkit-border-radius: 10px;
-
   background-color: #e6e6e6;
 
   border: 1px solid rgba(0, 0, 0, .3);

--- a/static/styles.css
+++ b/static/styles.css
@@ -53,8 +53,6 @@ body {
   -webkit-box-sizing: border-box;
 
   background-color: #e6e6e6;
-
-  border: 1px solid rgba(0, 0, 0, .3);
 .slides.layout-widescreen > article {
   margin-left: -550px;
   width: 1100px;

--- a/static/styles.css
+++ b/static/styles.css
@@ -64,11 +64,6 @@ body {
   width: 1100px;
 }
 
-.slides.layout-widescreen > article:not(.nobackground):not(.biglogo),
-.slides.layout-faux-widescreen > article:not(.nobackground):not(.biglogo) {
-  background-position-x: 0, 840px;
-}
-
 /* Clickable/tappable areas */
 
 .slide-area {

--- a/static/styles.css
+++ b/static/styles.css
@@ -219,7 +219,8 @@ body {
 }
 
 .slides > article > :not(footer) {
-  padding: 0 6%;
+  padding-left: 6%;
+  padding-right: 6%;
 }
 
 .slides > article:first-of-type,

--- a/static/styles.css
+++ b/static/styles.css
@@ -53,6 +53,7 @@ body {
   -webkit-box-sizing: border-box;
 
   background-color: #e6e6e6;
+}
 .slides.layout-widescreen > article {
   margin-left: -550px;
   width: 1100px;

--- a/static/styles.css
+++ b/static/styles.css
@@ -16,11 +16,7 @@ body {
   overflow-x: hidden;
   overflow-y: auto;
 
-  background: rgb(215, 215, 215);
-  background: -o-radial-gradient(rgb(240, 240, 240), rgb(190, 190, 190));
-  background: -moz-radial-gradient(rgb(240, 240, 240), rgb(190, 190, 190));
-  background: -webkit-radial-gradient(rgb(240, 240, 240), rgb(190, 190, 190));
-  background: -webkit-gradient(radial, 50% 50%, 0, 50% 50%, 500, from(rgb(240, 240, 240)), to(rgb(190, 190, 190)));
+  background: #000;
 
   -webkit-font-smoothing: antialiased;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -64,12 +64,6 @@ body {
   background-color: #e6e6e6;
 
   border: 1px solid rgba(0, 0, 0, .3);
-
-  transition: transform .3s ease-out;
-  -o-transition: -o-transform .3s ease-out;
-  -moz-transition: -moz-transform .3s ease-out;
-  -webkit-transition: -webkit-transform .3s ease-out;
-}
 .slides.layout-widescreen > article {
   margin-left: -550px;
   width: 1100px;

--- a/static/styles.css
+++ b/static/styles.css
@@ -230,7 +230,7 @@ h3 {
 
   font-weight: 300;
 
-  letter-spacing: -1px;
+  letter-spacing: -2px;
 
   color: rgb(51, 51, 51);
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -105,80 +105,19 @@ body {
   display: none;
 }
 .slides > article.far-past {
-  display: block;
-  transform: translate(-2040px);
-  -o-transform: translate(-2040px);
-  -moz-transform: translate(-2040px);
-  -webkit-transform: translate3d(-2040px, 0, 0);
+  display: none;
 }
 .slides > article.past {
-  display: block;
-  transform: translate(-1020px);
-  -o-transform: translate(-1020px);
-  -moz-transform: translate(-1020px);
-  -webkit-transform: translate3d(-1020px, 0, 0);
+  display: none;
 }
 .slides > article.current {
   display: block;
-  transform: translate(0);
-  -o-transform: translate(0);
-  -moz-transform: translate(0);
-  -webkit-transform: translate3d(0, 0, 0);
 }
 .slides > article.next {
-  display: block;
-  transform: translate(1020px);
-  -o-transform: translate(1020px);
-  -moz-transform: translate(1020px);
-  -webkit-transform: translate3d(1020px, 0, 0);
+  display: none;
 }
 .slides > article.far-next {
-  display: block;
-  transform: translate(2040px);
-  -o-transform: translate(2040px);
-  -moz-transform: translate(2040px);
-  -webkit-transform: translate3d(2040px, 0, 0);
-}
-
-.slides.layout-widescreen > article.far-past,
-.slides.layout-faux-widescreen > article.far-past {
-  display: block;
-  transform: translate(-2260px);
-  -o-transform: translate(-2260px);
-  -moz-transform: translate(-2260px);
-  -webkit-transform: translate3d(-2260px, 0, 0);
-}
-.slides.layout-widescreen > article.past,
-.slides.layout-faux-widescreen > article.past {
-  display: block;
-  transform: translate(-1130px);
-  -o-transform: translate(-1130px);
-  -moz-transform: translate(-1130px);
-  -webkit-transform: translate3d(-1130px, 0, 0);
-}
-.slides.layout-widescreen > article.current,
-.slides.layout-faux-widescreen > article.current {
-  display: block;
-  transform: translate(0);
-  -o-transform: translate(0);
-  -moz-transform: translate(0);
-  -webkit-transform: translate3d(0, 0, 0);
-}
-.slides.layout-widescreen > article.next,
-.slides.layout-faux-widescreen > article.next {
-  display: block;
-  transform: translate(1130px);
-  -o-transform: translate(1130px);
-  -moz-transform: translate(1130px);
-  -webkit-transform: translate3d(1130px, 0, 0);
-}
-.slides.layout-widescreen > article.far-next,
-.slides.layout-faux-widescreen > article.far-next {
-  display: block;
-  transform: translate(2260px);
-  -o-transform: translate(2260px);
-  -moz-transform: translate(2260px);
-  -webkit-transform: translate3d(2260px, 0, 0);
+  display: none;
 }
 
 /* Styles for slides */


### PR DESCRIPTION
Apply style changes to make the slides more consistent with the official GDS deck design.

Although the solid black background looks very harsh in the screenshots, it's not visible when using a projector. Using the page zoom in the browser makes it possible to reduce the size of the black border.

I did experiment with scaling the slides to the full width and height of the page, but this made the slide layout unpredictable when using screens/projectors of different resolutions. This could probably made to work by auto-scaling the <img> elements at some point in future.

## Before

![screen shot 2015-07-28 at 18 56 54](https://cloud.githubusercontent.com/assets/4348848/8939193/dce7b2f8-355a-11e5-998b-6f7f1fb5fa3b.png)
![screen shot 2015-07-28 at 18 57 08](https://cloud.githubusercontent.com/assets/4348848/8939197/dcecec64-355a-11e5-973b-bf7e6868ec7e.png)
![screen shot 2015-07-28 at 18 57 16](https://cloud.githubusercontent.com/assets/4348848/8939198/dcf034fa-355a-11e5-90f4-35e19aefad42.png)

## After

![screen shot 2015-07-28 at 18 52 37](https://cloud.githubusercontent.com/assets/4348848/8939191/dccf4966-355a-11e5-968c-119fafb644d0.png)
![screen shot 2015-07-28 at 18 52 29](https://cloud.githubusercontent.com/assets/4348848/8939190/dcce551a-355a-11e5-9e30-7c65c642cf6f.png)
![screen shot 2015-07-28 at 18 52 48](https://cloud.githubusercontent.com/assets/4348848/8939192/dcd509be-355a-11e5-8ce5-70aadde50a91.png)